### PR TITLE
Handle exception in requests.response.text.

### DIFF
--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -517,8 +517,8 @@ def adzerk_request(keywords, num_placements=1, timeout=1.5):
         response = adzerk_api.handle_response(r)
     except adzerk_api.AdzerkError:
         g.stats.simple_event('adzerk.request.badresponse')
-        g.log.error('adzerk_request: bad response (%s) %s', r.status_code,
-                    r.text)
+        g.log.error('adzerk_request: bad response (%s) %r', r.status_code,
+                    r.content)
         return None
 
     decisions = response['decisions']


### PR DESCRIPTION
This seems like a bug in the requests package.

The exception occurs here:
https://github.com/kennethreitz/requests/blob/master/requests/models.py#L773

because `encoding` is `None`

fixes the "Bassoons" exception

:eyeglasses: @umbrae @kemitche @dwick 