### PR TITLE
Use platform and mobile OS targeting.

### DIFF
--- a/reddit_adzerk/adzerk_api.py
+++ b/reddit_adzerk/adzerk_api.py
@@ -256,6 +256,7 @@ class Flight(Base):
         Field('ReferrerKeywords', optional=True),
         Field('WeightOverride', optional=True),
         Field('DeliveryStatus', optional=True),
+        Field('CustomTargeting', optional=True),
     )
 
     @classmethod

--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -236,11 +236,11 @@ def update_flight(link, campaign, az_campaign):
         })
 
     if campaign.mobile_os:
-        deviceQueries = ['($device.os = "%s")' % os
+        deviceQueries = ['($device.os contains "%s")' % os
                          for os in campaign.mobile_os]
 
         if campaign.platform == "all":
-            deviceQueries.append('($device.formFactor = "desktop")')
+            deviceQueries.append('($device.formFactor contains "desktop")')
         
         customTargeting = ' or '.join(deviceQueries)
         d.update({

--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -253,7 +253,7 @@ def update_flight(link, campaign, az_campaign):
                 'SiteId': g.az_selfserve_site_id,
                 'IsExclude': False,
             })
-        else if campaign.platform == 'mobile':
+        elif campaign.platform == 'mobile':
             siteZones.append({
                 'SiteId': g.az_selfserve_mobile_web_site_id,
                 'IsExclude': False,

--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -26,6 +26,7 @@ from r2.lib.utils import UrlParser
 from r2.lib.validator import (
     validate,
     VPrintable,
+    VBoolean,
 )
 
 from r2.models import (


### PR DESCRIPTION
for platform targeting, pass along the appropriate site id.  for os targeting, we need to add a custom targeting 'zerkel' query to the flight and pass the user agent along when making the request.  I have _not_ tested this on stagin yet (going to try to get to that today).

:eyeglasses: @bsimpson63 