### PR TITLE
Rename Adzerk API response timer for consistency with other timers.

### DIFF
--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -538,7 +538,7 @@ def adzerk_request(keywords, num_placements=1, timeout=1.5, mobile_web=False):
         'user-agent': request.headers.get('User-Agent'),
     }
 
-    timer = g.stats.get_timer("adzerk_timer")
+    timer = g.stats.get_timer("providers.adzerk")
     timer.start()
 
     try:


### PR DESCRIPTION
All of the providers are moving under a single tree for consistency and
cleanliness.

:eyeglasses: @bsimpson63 