### PR TITLE
3rd party adservers: handle response from adzerk

### DIFF
--- a/reddit_adzerk/__init__.py
+++ b/reddit_adzerk/__init__.py
@@ -25,7 +25,7 @@ class Adzerk(Plugin):
         ],
 
         ConfigValue.tuple_of(ConfigValue.int): [
-            'adserver_camp_ids',
+            'adserver_campaign_ids',
         ],
     }
 

--- a/reddit_adzerk/__init__.py
+++ b/reddit_adzerk/__init__.py
@@ -23,6 +23,10 @@ class Adzerk(Plugin):
         ConfigValue.dict(ConfigValue.str, ConfigValue.int): [
             'az_selfserve_priorities',
         ],
+
+        ConfigValue.tuple_of(ConfigValue.int) : [
+            'adserver_camp_ids',
+        ],
     }
 
     js = {

--- a/reddit_adzerk/__init__.py
+++ b/reddit_adzerk/__init__.py
@@ -24,7 +24,7 @@ class Adzerk(Plugin):
             'az_selfserve_priorities',
         ],
 
-        ConfigValue.tuple_of(ConfigValue.int) : [
+        ConfigValue.tuple_of(ConfigValue.int): [
             'adserver_camp_ids',
         ],
     }

--- a/reddit_adzerk/adzerk_api.py
+++ b/reddit_adzerk/adzerk_api.py
@@ -17,6 +17,9 @@ def handle_response(response):
     except ValueError:
         raise AdzerkError('bad response')
 
+class AdserverResponse(object):
+    def __init__(self, body):
+        self.body = body
 
 class Stub(object):
     def __init__(self, Id):

--- a/reddit_adzerk/adzerk_api.py
+++ b/reddit_adzerk/adzerk_api.py
@@ -17,9 +17,6 @@ def handle_response(response):
     except ValueError:
         raise AdzerkError('bad response')
 
-class AdserverResponse(object):
-    def __init__(self, body):
-        self.body = body
 
 class Stub(object):
     def __init__(self, Id):

--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -573,8 +573,11 @@ def adzerk_request(keywords, num_placements=1, timeout=1.5, mobile_web=False):
 
     # When an adservers tags are returned they are rendered
     # directly, not as a reddit link.
-    if decisions['div0']['campaignId'] in g.adserver_camp_ids:
-        return decisions['div0']['contents'][0]['body']
+    try:
+        if decisions['div0']['campaignId'] in g.adserver_camp_ids:
+            return decisions['div0']['contents'][0]['body']
+    except KeyError:
+        pass
 
     res = []
     for div in divs:
@@ -615,6 +618,7 @@ class AdzerkApiController(api.ApiController):
             g.stats.simple_event('adzerk.request.no_promo')
             return
 
+        # for adservers, adzerk returns markup so we pass it to the client
         if type(response) == unicode:
             return responsive(response)
 

--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -619,7 +619,8 @@ class AdzerkApiController(api.ApiController):
             return
 
         # for adservers, adzerk returns markup so we pass it to the client
-        if type(response) == unicode:
+        if isinstance(response, unicode):
+            g.stats.simple_event('adzerk.request.adserver')
             return responsive(response)
 
         res_by_campaign = {r.campaign: r for r in response}

--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -513,6 +513,11 @@ def process_adzerk():
 AdzerkResponse = namedtuple('AdzerkResponse',
                     ['link', 'campaign', 'target', 'imp_pixel', 'click_url'])
 
+class AdserverResponse(object):
+    def __init__(self, body):
+        self.body = body
+
+
 def adzerk_request(keywords, num_placements=1, timeout=1.5, mobile_web=False):
     placements = []
     divs = ["div%s" % i for i in xrange(num_placements)]
@@ -571,7 +576,6 @@ def adzerk_request(keywords, num_placements=1, timeout=1.5, mobile_web=False):
     if not decisions:
         return None
 
-
     res = []
     for div in divs:
         decision = decisions[div]
@@ -580,7 +584,7 @@ def adzerk_request(keywords, num_placements=1, timeout=1.5, mobile_web=False):
 
         # adserver ads are not reddit links, we return the body
         if decision['campaignId'] in g.adserver_campaign_ids:
-            return adzerk_api.AdserverResponse(decision['contents'][0]['body'])
+            return AdserverResponse(decision['contents'][0]['body'])
 
         imp_pixel = decision['impressionUrl']
         click_url = decision['clickUrl']
@@ -616,7 +620,7 @@ class AdzerkApiController(api.ApiController):
             return
 
         # for adservers, adzerk returns markup so we pass it to the client
-        if isinstance(response, adzerk_api.AdserverResponse):
+        if isinstance(response, AdserverResponse):
             g.stats.simple_event('adzerk.request.adserver')
             return responsive(response.body)
 

--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -574,7 +574,7 @@ def adzerk_request(keywords, num_placements=1, timeout=1.5, mobile_web=False):
     # When an adservers tags are returned they are rendered
     # directly, not as a reddit link.
     try:
-        if decisions['div0']['campaignId'] in g.adserver_camp_ids:
+        if decisions['div0']['campaignId'] in g.adserver_campaign_ids:
             return decisions['div0']['contents'][0]['body']
     except KeyError:
         pass

--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -571,6 +571,11 @@ def adzerk_request(keywords, num_placements=1, timeout=1.5, mobile_web=False):
     if not decisions:
         return None
 
+    # When an adservers tags are returned they are rendered
+    # directly, not as a reddit link.
+    if decisions['div0']['campaignId'] in g.adserver_camp_ids:
+        return decisions['div0']['contents'][0]['body']
+
     res = []
     for div in divs:
         decision = decisions[div]
@@ -609,6 +614,9 @@ class AdzerkApiController(api.ApiController):
         if not response:
             g.stats.simple_event('adzerk.request.no_promo')
             return
+
+        if type(response) == unicode:
+            return responsive(response)
 
         res_by_campaign = {r.campaign: r for r in response}
         tuples = [promote.PromoTuple(r.link, 1., r.campaign) for r in response]


### PR DESCRIPTION
When adzerk returns markup from a third party adserver
we need to pass that directly to the client since it
is not a reddit link.

related to #830 in private
:eyeglasses: @zeantsoi 