### PR TITLE
Pass id36 to Adzerk rather than id

### DIFF
--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -666,7 +666,7 @@ class AdzerkApiController(api.ApiController):
 
     def get_uid(self, loid):
         if c.user_is_loggedin:
-            return c.user._id
+            return c.user._id36
         elif loid:
             return loid
         else:


### PR DESCRIPTION
:eyeglasses: @dwick 

There may be an issue with passing an `int` type to the Adzerk request. This will pass a `str` type, which has proven to work in the case of logged out users via the `loid`.