### PR TITLE
Force bytestring when logging changes

### DIFF
--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -108,7 +108,7 @@ def make_change_strings(changed):
             newval = date_from_adzerk(newval)
             oldval = date_from_adzerk(oldval)
 
-        return '%s: %s -> %s' % (attr, oldval, newval)
+        return '%s: %s -> %s' % (attr, _force_utf8(oldval), _force_utf8(newval))
 
     return map(change_to_str, changed)
 


### PR DESCRIPTION
:eyeglasses: @bsimpson63 @spladug 

Old problem recurring as documented in [JIRA ADS-260](https://reddit.atlassian.net/browse/ADS-260).

This change sanitizes all strings to bytestrings prior to sending to the logger. The operation only takes effect on strings containing non-ASCII characters; it is idempotent on strings comprised entirely on ASCII chars.