### PR TITLE
Display ads: Fix firefox fragment encoding issue.

### DIFF
--- a/reddit_adzerk/public/static/js/adzerk/display.js
+++ b/reddit_adzerk/public/static/js/adzerk/display.js
@@ -19,6 +19,11 @@
     // see http://stackoverflow.com/a/1704842/704286
     var hash = location.href.split('#')[1] || '';
 
+    // Firefox automatically encodes thing the fragment, but not other browsers.
+    if (/^\{%22/.test(hash)) {
+      hash = decodeURIComponent((hash));
+    }
+
     try {
       return $.parseJSON(hash);
     } catch (e) {


### PR DESCRIPTION
Firefox automatically url encodes the hash fragment where as
other browsers don't.  Since we're expecting the entire fragment
to be json we can simply check that the string starts with `{%22`
and decode it.

:eyeglasses: @zeantsoi 