### PR TITLE
Fix ssl for preview links

### DIFF
--- a/reddit_adzerk/templates/baseadframe.html
+++ b/reddit_adzerk/templates/baseadframe.html
@@ -52,7 +52,7 @@ ${self.content()}
 
           var id = window.parent.frames[frame].ados_ads[placement].id;
           var discussLink = document.createElement('a');
-          var adzerkPreview = 'https://preview.adzerk.net/preview/' + id;
+          var adzerkPreview = 'https://preview.adzerk.com/preview/' + id;
 
           discussLink.className = 'discuss-ad';
           discussLink.target = 'top';


### PR DESCRIPTION
:eyeglasses: @zeantsoi 


From james:
> Can you change your client script to use preview.adzerk.com instead of preview.adzerk.net? I tried to add an SSL cert for preview.adzerk.net but they don't make a cert that will let us do preview.adzerk.net and *.adzerk.com (or any multiple wildcard domains). 