### PR TITLE
Fix bug with ads being skipped when they should not be

### DIFF
--- a/reddit_adzerk/public/static/js/adzerk/display.js
+++ b/reddit_adzerk/public/static/js/adzerk/display.js
@@ -40,8 +40,8 @@
     var skipAd = false;
 
     if (global.SKIP_AD_KEYWORDS && keywords) {
-      for (var keyword in keywords) {
-        if ($.inArray(keyword, global.SKIP_AD_KEYWORDS)) {
+      for (var i = 0; i < keywords.length; i++) {
+        if ($.inArray(keywords[i], global.SKIP_AD_KEYWORDS)) {
           skipAd = true;
           break;
         }


### PR DESCRIPTION
`keywords` is an array and needs to be iterated as such.

:eyeglasses: @zeantsoi 

before:
<img width="1084" alt="screen shot 2015-12-18 at 1 13 45 pm" src="https://cloud.githubusercontent.com/assets/823747/11907527/76837476-a589-11e5-8eba-056d71734d53.png">
after:
<img width="1086" alt="screen shot 2015-12-18 at 1 15 30 pm" src="https://cloud.githubusercontent.com/assets/823747/11907528/7b0c18e0-a589-11e5-873d-9e1e1d156ade.png">
