### PR TITLE
Stop unnecessarily updating `SiteZoneTargeting`

### DIFF
--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -381,12 +381,28 @@ def update_flight(link, campaign):
         })
 
     if campaign.platform != 'all':
-        d.update({
-            'SiteZoneTargeting': [{
-                'SiteId': g.az_selfserve_site_ids[campaign.platform],
-                'IsExclude': False,
-            }],
-        })
+        site_targeting = [{
+            'SiteId': g.az_selfserve_site_ids[campaign.platform],
+            'IsExclude': False,
+            'ZoneId': None,
+            'FlightId': az_flight.Id if az_flight else None,
+        }]
+        # Check equality more specifically to reduce spam in the PromotionLog.
+        update_site_targeting = True
+        if az_flight and az_flight.SiteZoneTargeting:
+            # Loop through the existing site targeting and remove the `Id` param.
+            old_site_targeting = map(
+                lambda (index, value): {
+                    key: value[key]
+                    for key in value.keys() if key != "Id"},
+                enumerate(az_flight.SiteZoneTargeting),
+            )
+            update_site_targeting = old_site_targeting != site_targeting
+
+        if update_site_targeting:
+            d.update({
+                'SiteZoneTargeting': site_targeting,
+            })
 
     # special handling for location conversions between reddit and adzerk
     if campaign.location:


### PR DESCRIPTION
SiteZoneTargeting hardly ever changes, but causes unchanged flights
to be updated unnecessarily/spam the `PromotionLog` because adzerk
also includes `Id`s in the GET results.


:eyeglasses: @zeantsoi 