### PR TITLE
Ensure that GroupBy passes a value

### DIFF
--- a/reddit_adzerk/report.py
+++ b/reddit_adzerk/report.py
@@ -65,6 +65,9 @@ def demangle_frontpage_name(keyword):
 
 
 def queue_report(start, end, groups=None, parameters=None):
+    if not groups:
+        groups = []
+
     data = {
         "StartDate": start.strftime("%m/%d/%Y"),
         "EndDate": end.strftime("%m/%d/%Y"),


### PR DESCRIPTION
:eyeglasses: @kjoconnor 

cc: @dwick 

Per Adzerk, we need to pass a value, otherwise we get a 400 response: `{"message":"Argument cannot be null.\nParameter name: source"}`.