### PR TITLE
Add a custom property to the ad request for the percentage of users

### DIFF
--- a/reddit_adzerk/public/static/js/adzerk/display.js
+++ b/reddit_adzerk/public/static/js/adzerk/display.js
@@ -32,6 +32,11 @@
   }
 
   var config = getConfig();
+  var properties = config.properties || {};
+
+  // Allows the yield manager to target a percentage of users
+  // with specific SSPs.
+  properties.percentage = Math.round(Math.random());
 
   // Display a random image in lieu of an ad for certain keywords.
   // This reduces the number of ad requests for low-fill targets.
@@ -76,12 +81,12 @@
 
         placement = ados_add_placement(NETWORK, SITE, type, PLACEMENT_TYPES[type]);
         placement.setFlightCreativeId(creative);
-        placement.setProperties(config.properties);
+        placement.setProperties(properties);
       }
     } else {
       for (var type in PLACEMENT_TYPES) {
         placement = ados_add_placement(NETWORK, SITE, type, PLACEMENT_TYPES[type]);
-        placement.setProperties(config.properties);
+        placement.setProperties(properties);
       }
     }
     


### PR DESCRIPTION
This can be targeting via [custom targeting](http://help.adzerk.com/hc/en-us/sections/200425869-Custom-Targeting):

`(percentage > 0 and percentage <= 20)`

ticket: https://reddit.atlassian.net/browse/ADS-527