### PR TITLE
Proxy postMessages down to the ad frame

### DIFF
--- a/reddit_adzerk/public/static/js/adzerk/adzerk.js
+++ b/reddit_adzerk/public/static/js/adzerk/adzerk.js
@@ -30,10 +30,18 @@
       return;
     }
 
-    var message = e.data.split(':');
+    var data = e.data;
 
-    if (message[0] == 'ados.createAdFrame') {
-      r.adzerk.createSponsorshipAdFrame();
+    if (typeof data === 'string') {
+      var message = data.split(':');
+
+      if (message[0] == 'ados.createAdFrame') {
+        r.adzerk.createSponsorshipAdFrame();
+      }
+    }
+
+    if (window.frames.ad_main && window.frames.ad_main.postMessage) {
+      window.frames.ad_main.postMessage(data, '*');
     }
   });
 


### PR DESCRIPTION
👓 @tsegaran @aoiwelle 

This should hopefully fix the adx passback: http://help.adzerk.com/hc/en-us/articles/203360135-Alternate-Passback-Code-for-Use-With-Iframes

Adzerk expects the top frame to be the one serving the ad via their ados.js.  We serve the ads from iframes (/ads/300x250) so we need to pass the messages back down to ados to handle.  Currently the passback also throws an error because the postMessage handler expects only strings.

I haven't been able to test this because I can't seem to get the passback to fire anymore.

Maybe @averyj can lend a hand with that.

