### PR TITLE
Fix `target_name` for multi-subreddit targeting being too long.

### DIFF
--- a/reddit_adzerk/adzerkreporting.py
+++ b/reddit_adzerk/adzerkreporting.py
@@ -379,10 +379,19 @@ def _process_daily_link_report(link, report_id, queued_date):
             values["spent_pennies"] = values["spent_pennies"] + (spent * 100.)
 
         for (campaign, date), values in campaign_details.iteritems():
+            # hack around `target_name`s for multi subreddit collections
+            # being overly long.
+            if (campaign.target.is_collection and
+                    "/r/" in campaign.target.pretty_name):
+
+                subreddit = "multi_%s" % PromoCampaign.SUBREDDIT_TARGET
+            else:
+                subreddit = campaign.target_name
+
             _insert_daily_campaign_reporting(
                 codename=campaign._fullname,
                 date=date,
-                subreddit=campaign.target_name,
+                subreddit=subreddit,
                 **values
             )
 


### PR DESCRIPTION
They're causing the db to error with:
	sqlalchemy.exc.OperationalError: (OperationalError) index
	row requires 41136 bytes, maximum size is 8191

👓 @zeantsoi @kjoconnor 

ticket: https://reddit.atlassian.net/browse/ADS-573