### PR TITLE
Search for the correct window before firing the passback

### DIFF
--- a/reddit_adzerk/templates/passback.html
+++ b/reddit_adzerk/templates/passback.html
@@ -8,7 +8,36 @@
 </head>
 <body>
   <script>
-    window.top.postMessage({flightId: ${scriptsafe_dumps(thing.passback_id)}}, '*');
+    var adosWindow = window;
+    var PASSBACK_ID = ${scriptsafe_dumps(thing.passback_id)};
+
+    try {
+      while (!adosWindow.divName) {
+        // jshint eqeqeq: false
+        // cannot compare window objects with `===`
+        if (adosWindow == adosWindow.parent) {
+          break;
+        }
+
+        adosWindow = adosWindow.parent
+      }
+
+      if (adosWindow.divName) {
+        (adosWindow.ados_passback || adosWindow.parent.ados_passback)(adosWindow.divName, PASSBACK_ID);
+      }
+    } catch (e) {
+      var windows = []
+      var currentWindow = window;
+
+      while (currentWindow != currentWindow.parent) {
+          currentWindow = currentWindow.parent;
+          windows.push(currentWindow);
+      }
+
+      for (var i = 0; i < windows.length; i++) {
+        windows[i].postMessage({flightId: PASSBACK_ID}, '*')
+      }
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
👓 @aoiwelle 

This crazy bit of code looks for the `divName` property in windows above the adx passback.  If it errors it has hit an unfriendly iframe so it fires off `postMessage` events to every frame at that level, which hopefully is the correct frame.

Seemed to work when tested via the js console.  Current code doesn't work so I don't see any harm in trying this.