### PR TITLE
Fix priority id not being mapped to names

### DIFF
--- a/reddit_adzerk/adzerkpromote.py
+++ b/reddit_adzerk/adzerkpromote.py
@@ -1132,7 +1132,12 @@ def adzerk_request(
         ecpm = body.get('ecpm', None)
         moat_query = body.get('moatQuery', None)
 
-        if priority_id:
+        if priority_id is not None:
+            try:
+                priority_id = int(priority_id)
+            except ValueError:
+                pass
+
             for k, v in g.az_selfserve_priorities.iteritems():
                 if priority_id == v:
                     priority = k


### PR DESCRIPTION
👓 @aoiwelle 

everything is currently coming in as `unknown (number)` because `priorityId` is a string.

https://interana.data.uw2.snooguts.net/s/b389RL

ticket: https://reddit.atlassian.net/browse/ADS-660